### PR TITLE
Add examples of control requests

### DIFF
--- a/SDKMessageExample.sln
+++ b/SDKMessageExample.sln
@@ -7,20 +7,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDKMessageExample", "SDKMes
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Debug|x64.ActiveCfg = Debug|x64
-		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Debug|x64.Build.0 = Debug|x64
 		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Debug|x86.ActiveCfg = Debug|Win32
 		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Debug|x86.Build.0 = Debug|Win32
-		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Release|x64.ActiveCfg = Release|x64
-		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Release|x64.Build.0 = Release|x64
-		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Release|x86.ActiveCfg = Release|Win32
-		{34FB644A-9C00-4036-ABB5-3FE8400356A3}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
QPS insisted that the control RPCs were not working, so I tested them locally. I figured that we should just go ahead and add this to the SDK example to speed up future integrations. 
